### PR TITLE
feat: Implement chat endpoint with OpenAI API

### DIFF
--- a/src/main/java/com/oraculo/ai/oraculoai/controllers/OraculoController.java
+++ b/src/main/java/com/oraculo/ai/oraculoai/controllers/OraculoController.java
@@ -1,0 +1,23 @@
+package com.oraculo.ai.oraculoai.controllers;
+
+import org.springframework.ai.openai.OpenAiChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping ("oraculo")
+public class OraculoController {
+    
+    private OpenAiChatClient chatClient;
+
+    public OraculoController(OpenAiChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+     @GetMapping("question")
+    public String oraculoChat(@RequestBody String message) {
+        return chatClient.call(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=oraculo-ai
+#spring.ai.openai.api-key=suachaveopenai


### PR DESCRIPTION
Create a new endpoint `/oraculo/question` in the OraculoController to handle incoming chat messages. Utilize the OpenAiChatClient to process the messages and return responses. This commit establishes the basic structure for integrating OpenAI's API into the chat service.